### PR TITLE
CI: install libeigen3-dev for eaik compilation

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,6 +39,9 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libeigen3-dev
+
       - name: Bootstrap siblings
         env:
           # While any sibling repo is still private, setup.sh needs auth to clone.


### PR DESCRIPTION
## Summary
Nightly integration fails because `eaik` (Eigen-based IK) is sdist-only and requires `libeigen3-dev` to compile. The Ubuntu runner doesn't have it.

Fixes #8, fixes #9

## Test plan
- [ ] Integration workflow passes (eaik compiles successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)