### PR TITLE
setup.sh: wipe stale per-package .venv dirs before uv sync (#62)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -42,6 +42,17 @@ else
 fi
 
 echo ""
+echo "==> Removing stale per-package venvs (workspace uses shared root .venv)..."
+# `uv run` inside a workspace member with its own .venv ignores the shared
+# workspace venv, which is a common silent footgun. See robot-code#62.
+shopt -s nullglob
+for d in */.venv; do
+    echo "    removing $d"
+    rm -rf "$d"
+done
+shopt -u nullglob
+
+echo ""
 echo "==> Installing Python workspace (uv sync)..."
 uv sync
 


### PR DESCRIPTION
## Summary
- `uv run` inside a workspace member with its own `.venv/` directory uses that local venv instead of the shared workspace one. Per-package venvs can be missing transitive deps that the workspace `uv sync` would install — silently producing `ModuleNotFoundError`.
- This was the root cause that masked the dep-declaration bugs fixed in [personalrobotics/mj_manipulator#163](https://github.com/personalrobotics/mj_manipulator/pull/163), [personalrobotics/ada_mj#38](https://github.com/personalrobotics/ada_mj/pull/38), and [personalrobotics/geodude#195](https://github.com/personalrobotics/geodude/pull/195).
- Adds a wipe step before `uv sync`. Idempotent.

Fixes #62

## Test plan
- [x] Ran setup.sh-equivalent locally: wiped `ada_mj/.venv`, `ada_assets/.venv`, `mj_manipulator_ros/.venv`, re-synced, launched `python -m ada_mj --demo feeding --viser` cleanly.
- [ ] After fresh clone, `./setup.sh` should not leave any per-package `.venv` and all CLIs should work with `--viser`.

## Out of scope
- `setup.sh` doesn't clone `ada_assets` / `ada_mj` even though they're workspace members. Worth filing separately.