### PR TITLE
uv: declare workspace sources at root (fix geodude build in CI, #74)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,23 @@ members = [
     "pycbirrt",
     "tsr",
 ]
+
+# Resolve every inter-member dependency from the workspace, declared at the
+# root so the mapping is authoritative for all members. Members also declare
+# these in their own pyprojects (for standalone use), but uv 0.11 validates a
+# member's `workspace = true` sources while *building* it and rejects them if
+# the workspace context isn't established at the root — which is what broke
+# `uv sync` on geodude (-> mj-viser "is not a workspace member"). See #74.
+[tool.uv.sources]
+ada-assets = { workspace = true }
+ada-mj = { workspace = true }
+asset-manager = { workspace = true }
+geodude = { workspace = true }
+geodude-assets = { workspace = true }
+mj-environment = { workspace = true }
+mj-manipulator = { workspace = true }
+mj-manipulator-ros = { workspace = true }
+mj-viser = { workspace = true }
+prl-assets = { workspace = true }
+pycbirrt = { workspace = true }
+tsr = { workspace = true }


### PR DESCRIPTION
Fixes #74. Candidate fix for the pre-existing `uv sync` failure (`Failed to build geodude → mj-viser is not a workspace member`).

## Diagnosis
- uv **0.11.18** (CI's `setup-uv@v5`) regression vs 0.7.3: it validates a member's `workspace = true` sources **while building that member**, and rejects them when the workspace source mapping isn't declared at the **root**.
- The virtual root `pyproject.toml` declared **no `[tool.uv.sources]`** — each member declared its own — so building geodude failed.
- Not reproducible on macOS (lock + member wheel builds succeed); reproduces only on the Linux CI runner with 0.11.18.

## Fix
Declare the full member source map (`{ workspace = true }`) at the workspace root. Resolution is unchanged locally (`uv.lock` identical), so this is non-breaking.

Verification is on this PR's CI: if the `integration` job gets past the geodude build step, the fix holds.