### PR TITLE
setup.sh: populate empty gitlink placeholder dirs (fix CI, #74)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -36,11 +36,17 @@ cd "$(dirname "$0")"
 echo "==> Cloning repos..."
 for url in "${REPOS[@]}"; do
     dir=$(basename "$url")
-    if [ ! -d "$dir" ]; then
-        echo "    cloning $dir"
-        git clone "$url"
-    else
+    # Several siblings are tracked as gitlinks (submodule-style pointers) but
+    # there is no .gitmodules, so a fresh checkout leaves them as EMPTY
+    # placeholder directories. A plain `[ ! -d ]` guard would see the dir and
+    # skip it, leaving an empty (broken) uv workspace member. Detect a populated
+    # repo by its .git entry instead, and clone into the empty placeholder.
+    if [ -e "$dir/.git" ]; then
         echo "    $dir already present, skipping"
+    else
+        echo "    cloning $dir"
+        rm -rf "$dir"        # drop the empty gitlink placeholder, if any
+        git clone "$url"
     fi
 done
 


### PR DESCRIPTION
## Root cause (confirmed via CI probe)
Several siblings are tracked as **gitlinks** (submodule-style pointers) but the repo has **no `.gitmodules`**. So on a fresh CI checkout (`actions/checkout` with `submodules: false`), `mj_viser`, `ada_assets`, `ada_mj`, `mj_manipulator_ros`, … are left as **empty placeholder directories**.

`setup.sh`'s `[ ! -d "$dir" ]` guard then saw the dir exists and printed *"already present, skipping"* — never cloning them. Empty dirs = broken uv workspace members → `uv sync` failed building geodude with *"mj-viser is not a workspace member."*

The uv `[tool.uv.sources]` were a **red herring** (they resolve fine once the member dirs are populated — verified locally).

## Fix
Detect a *populated* repo by its `.git` entry rather than mere directory existence, and clone into the empty placeholder. One-line logic change.

Fixes #74. Verified on this PR's CI: if `uv sync` gets past the empty-member errors, the fix holds.